### PR TITLE
[PDF Ingestor] make sure key idx within the range of sorted freq keys

### DIFF
--- a/nlm_ingestor/ingestor/pdf_ingestor.py
+++ b/nlm_ingestor/ingestor/pdf_ingestor.py
@@ -232,7 +232,7 @@ def top_pages_info(parsed_doc):
     def retrieve_title_candidates(key_idx):
         temp_ = []
         title_candidates_ = []
-        if len(sorted_freq) > 0:
+        if len(sorted_freq) > 0 and len(list(sorted_freq.keys())) > key_idx:
             for freq_ in sorted_freq[list(sorted_freq.keys())[key_idx]]:
                 if (parsed_doc.blocks[freq_["enum_idx"]]["box_style"][0] >= parsed_doc.page_height / 2) or \
                         not len(text_only_pattern.sub("", freq_["text"]).strip()):


### PR DESCRIPTION
## Description of the change
 make sure key idx within the range of sorted freq keys to void some ingestion failed for certain pdf files

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)

## Related issues

> Fix [#1]()

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request
