### PR TITLE
Update to nlm 2.9.2 v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ There are two ways to process these types of documents
 1. Install latest version of java from https://www.oracle.com/java/technologies/downloads/
 2. Run the tika server:
 ```
- java -jar <path_to_nlm_ingestor>/jars/tika-server-standard-nlm-modified-2.9.2_v1.jar
+ java -jar <path_to_nlm_ingestor>/jars/tika-server-standard-nlm-modified-2.9.2_v2.jar
 ```
 3. Install the ingestor
 ```

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ There are two ways to process these types of documents
 1. Install latest version of java from https://www.oracle.com/java/technologies/downloads/
 2. Run the tika server:
 ```
- java -jar <path_to_nlm_ingestor>/jars/tika-server-standard-nlm-modified-2.4.1_v6.jar
+ java -jar <path_to_nlm_ingestor>/jars/tika-server-standard-nlm-modified-2.9.2_v1.jar
 ```
 3. Install the ingestor
 ```

--- a/nlm_ingestor/file_parser/tika_parser.py
+++ b/nlm_ingestor/file_parser/tika_parser.py
@@ -16,7 +16,9 @@ class TikaFileParser(FileParser):
         # Turn off OCR by default
         timeout = 3000
         headers = {
-            "X-Tika-OCRskipOcr": "true"
+            "X-Tika-OCRskipOcr": "true",
+            "X-Tika-PDFOcrStrategy": "auto",
+            "X-Tika-PDFExtractFontNames": "true"
         }
         if do_ocr:
             headers = {

--- a/nlm_ingestor/file_parser/tika_parser.py
+++ b/nlm_ingestor/file_parser/tika_parser.py
@@ -23,6 +23,7 @@ class TikaFileParser(FileParser):
                 "X-Tika-OCRskipOcr": "false",
                 "X-Tika-OCRoutputType": "hocr",
                 "X-Tika-Timeout-Millis": str(100 * timeout),
+                "X-Tika-PDFOcrStrategy": "ocr_only",
                 "X-Tika-OCRtimeoutSeconds": str(timeout),
             }
 

--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 # latest version of java and a python environment where requirements are installed is required
-nohup java -jar jars/tika-server-standard-nlm-modified-2.9.2_v1.jar > /dev/null 2>&1 &
+nohup java -jar jars/tika-server-standard-nlm-modified-2.9.2_v2.jar > /dev/null 2>&1 &
 python -m nlm_ingestor.ingestion_daemon

--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 # latest version of java and a python environment where requirements are installed is required
-nohup java -jar jars/tika-server-standard-nlm-modified-2.4.1_v6.jar > /dev/null 2>&1 &
+nohup java -jar jars/tika-server-standard-nlm-modified-2.9.2_v1.jar > /dev/null 2>&1 &
 python -m nlm_ingestor.ingestion_daemon


### PR DESCRIPTION
## Description of the change
  * This PR updates the Tika server version from 2.9.2_v1 to 2.9.2_v2 and adds new headers to the TikaFileParser.
  * New headers `X-Tika-PDFOcrStrategy` and `X-Tika-PDFExtractFontNames` have been added to the TikaFileParser for better control of the OCR and PDF parsing behavior.
  * 2.9.2_v1 failed to included necessary style attributes when computing `<p>` tags. New jar resolves this bug.


## Type of change
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Testing
The changes have been tested manually to ensure the Tika server works correctly with the new configuration and headers.  Additional testing is required for edge cases.  

