### PR TITLE
Specify NLTK data directory in Dockerfile and add build test

### DIFF
--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -1,0 +1,30 @@
+name: Docker
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+jobs:
+  test_docker_image:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      # - ame: Build image
+      #   run:
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          load: true
+          tags: nlm-sut
+      - name: Smoke test
+        run: |
+          docker run -d -p 5010:5001 nlm-sut
+          sleep 20
+          curl http://localhost:5010/

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,8 +30,8 @@ RUN pip install --upgrade pip setuptools
 RUN apt-get install -y libmagic1
 RUN mkdir -p -m 0600 ~/.ssh && ssh-keyscan github.com >> ~/.ssh/known_hosts
 RUN pip install -r requirements.txt
-RUN python -m nltk.downloader stopwords
-RUN python -m nltk.downloader punkt
+RUN python -m nltk.downloader -d /usr/share/nltk_data stopwords
+RUN python -m nltk.downloader -d /usr/share/nltk_data punkt
 RUN python -c "import tiktoken; tiktoken.get_encoding(\"cl100k_base\")"
 RUN chmod +x run.sh
 EXPOSE 5001


### PR DESCRIPTION
## Description of the change
- Specify NLTK data directory in Dockerfile when running downloaders for `punkt` and `stopwords`.
- add a docker build smoke test (sleep at 20s because that seems to be how long it takes to boot up the jar)
## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

- Fixes #85 

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [x] Issue from task tracker has a link to this pull request
