### PR TITLE
fix bug in new_indent_parser

### DIFF
--- a/nlm_ingestor/ingestor/visual_ingestor/new_indent_parser.py
+++ b/nlm_ingestor/ingestor/visual_ingestor/new_indent_parser.py
@@ -238,7 +238,7 @@ class NewIndentParser(object):
                 curr_header = block
             if curr_header and block['block_type'] in ['para', 'table', 'list', 'table_row']:
                 block['level'] = curr_header['level'] + 1
-            if block['block_type'] in ['list_item']:
+            if curr_header and block['block_type'] in ['list_item']:
                 if prev_block and prev_block['block_type'] in ['para', 'list_item'] and \
                         prev_block['block_text'].endswith(':'):
                     block['level'] = curr_header['level'] + 1


### PR DESCRIPTION
If `curr_header` is not set first, this leads to a type error, see #21

## Description of the change

Check if `curr_header` is initialized in the same way as in the `if` statement above.

## Type of change
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#21]()

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [x] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request
