### PR TITLE
fix: Adds key check to prevent error throw in switch statement

### DIFF
--- a/nlm_ingestor/ingestor/visual_ingestor/visual_ingestor.py
+++ b/nlm_ingestor/ingestor/visual_ingestor/visual_ingestor.py
@@ -3333,10 +3333,10 @@ class Doc:
                 del block['visual_lines']
             if 'orig_vls' in block:
                 del block['orig_vls']
-            if 'effective_header' in block:
-                del block['effective_header']['visual_lines']
-            if 'effective_para' in block:
-                del block['effective_para']['visual_lines']
+            if 'effective_header' in block and 'visual_lines' in block['effective_header']:
+                 del block['effective_header']['visual_lines']
+            if 'effective_para' in block and 'visual_lines' in block['effective_para']:
+                 del block['effective_para']['visual_lines']
             if 'child_blocks' in block:
                 for child_block in block['child_blocks']:
                     if 'visual_lines' in child_block:


### PR DESCRIPTION
## Description of the change

> This change ensures that the `visual_lines` key is only deleted from `effective_header` and `effective_para` if it exists within those dictionaries. This prevents potential key errors when the key is missing, improving the robustness of the code.  `visual_lines` is not a guaranteed field.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

None.


## Error:
```shell
2024-08-19 19:48:40 processing blocks in page:  414
2024-08-19 19:48:46 ERROR:__main__:error uploading file, stacktrace: Traceback (most recent call last):
2024-08-19 19:48:46   File "/app/nlm_ingestor/ingestion_daemon/__main__.py", line 48, in parse_document
2024-08-19 19:48:46     return_dict, _ = ingestor_api.ingest_document(
2024-08-19 19:48:46                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-08-19 19:48:46   File "/app/nlm_ingestor/ingestor/ingestor_api.py", line 37, in ingest_document
2024-08-19 19:48:46     ingestor = pdf_ingestor.PDFIngestor(doc_location, parse_options)
2024-08-19 19:48:46                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-08-19 19:48:46   File "/app/nlm_ingestor/ingestor/pdf_ingestor.py", line 35, in __init__
2024-08-19 19:48:46     blocks, _block_texts, _sents, _file_data, result, page_dim, num_pages = parse_blocks(
2024-08-19 19:48:46                                                                             ^^^^^^^^^^^^^
2024-08-19 19:48:46   File "/app/nlm_ingestor/ingestor/pdf_ingestor.py", line 181, in parse_blocks
2024-08-19 19:48:46     parsed_doc.compress_blocks()
2024-08-19 19:48:46   File "/app/nlm_ingestor/ingestor/visual_ingestor/visual_ingestor.py", line 3337, in compress_blocks
2024-08-19 19:48:46     del block['effective_header']['visual_lines']
2024-08-19 19:48:46         ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^
2024-08-19 19:48:46 KeyError: 'visual_lines'
2024-08-19 19:48:46 Traceback (most recent call last):
2024-08-19 19:48:46   File "/app/nlm_ingestor/ingestion_daemon/__main__.py", line 48, in parse_document
2024-08-19 19:48:46     return_dict, _ = ingestor_api.ingest_document(
2024-08-19 19:48:46                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-08-19 19:48:46   File "/app/nlm_ingestor/ingestor/ingestor_api.py", line 37, in ingest_document
2024-08-19 19:48:46     ingestor = pdf_ingestor.PDFIngestor(doc_location, parse_options)
2024-08-19 19:48:46                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-08-19 19:48:46   File "/app/nlm_ingestor/ingestor/pdf_ingestor.py", line 35, in __init__
2024-08-19 19:48:46     blocks, _block_texts, _sents, _file_data, result, page_dim, num_pages = parse_blocks(
2024-08-19 19:48:46                                                                             ^^^^^^^^^^^^^
2024-08-19 19:48:46   File "/app/nlm_ingestor/ingestor/pdf_ingestor.py", line 181, in parse_blocks
2024-08-19 19:48:46     parsed_doc.compress_blocks()
2024-08-19 19:48:46   File "/app/nlm_ingestor/ingestor/visual_ingestor/visual_ingestor.py", line 3337, in compress_blocks
2024-08-19 19:48:46     del block['effective_header']['visual_lines']
2024-08-19 19:48:46         ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^
2024-08-19 19:48:46 KeyError: 'visual_lines'
2024-08-19 19:48:46 192.168.65.1 - - [19/Aug/2024 23:48:46] "POST /api/parseDocument?renderFormat=all&applyOcr=no HTTP/1.1" 500 -
2024-08-19 19:48:46 INFO:werkzeug:192.168.65.1 - - [19/Aug/2024 23:48:46] "POST /api/parseDocument?renderFormat=all&applyOcr=no HTTP/1.1" 500 -
```
### Steps to recreate.

Parse [this document](https://www.nasa.gov/wp-content/uploads/2015/04/dressing-for-altitude-ebook_tagged.pdf?emrc=76e285) with applyOcr=no

### Development

- [x] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development