### PR TITLE
Fix bug where we cannot parse weird unicode characters to int.

### DIFF
--- a/nlm_ingestor/ingestor/visual_ingestor/indent_parser.py
+++ b/nlm_ingestor/ingestor/visual_ingestor/indent_parser.py
@@ -42,7 +42,7 @@ def get_list_item_sum(number, list_type):
         for c in number.split("."):
             if len(c) == 1:
                 new_number += "0"
-            if c.isdigit():
+            if c.isdecimal():
                 new_number += c
         return int(new_number)
     elif list_type == "letter":


### PR DESCRIPTION


## Description of the change

Weird unicode characters are digits, but not decimals. we can only cast decimals to int. We observed the following string in a pdf:  '➃703'

In python, we have:
```
>>> x
'➃'
>>> x.isdigit()
True
>>> x.isdecimal()
False
>>> int(x)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: invalid literal for int() with base 10: '➃'
>>>
```

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]()

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request
