### PR TITLE
Fix type error in check_line_between_box_styles: convert string coord…

### DIFF
--- a/nlm_ingestor/ingestor/visual_ingestor/visual_ingestor.py
+++ b/nlm_ingestor/ingestor/visual_ingestor/visual_ingestor.py
@@ -4585,28 +4585,37 @@ class Doc:
             right2 = curr_blk_box_style[2]
 
             for line in lines_tag_list:
-                # Not doing exact match on top of the next element as sometimes lines are thick
-                if bottom1 <= line['y1'] <= (top2 + 2.0) and \
-                        line['x1'] <= left1 <= line['x2'] and \
-                        line['x1'] <= left2 <= line['x2'] and \
-                        line['x1'] < right1 <= line['x2'] and \
-                        line['x1'] < right2 <= line['x2']:
-                    if check_gap:
-                        if abs(abs(line['y1'] - bottom1) - abs(top2 - line['y1'])) < 2.0:
+                try:
+                    # Try to convert coordinates to float, skip this line if conversion fails
+                    line_y1 = float(line['y1']) if isinstance(line['y1'], str) else line['y1']
+                    line_x1 = float(line['x1']) if isinstance(line['x1'], str) else line['x1']
+                    line_x2 = float(line['x2']) if isinstance(line['x2'], str) else line['x2']
+                    
+                    # Not doing exact match on top of the next element as sometimes lines are thick
+                    if bottom1 <= line_y1 <= (top2 + 2.0) and \
+                            line_x1 <= left1 <= line_x2 and \
+                            line_x1 <= left2 <= line_x2 and \
+                            line_x1 < right1 <= line_x2 and \
+                            line_x1 < right2 <= line_x2:
+                        if check_gap:
+                            if abs(abs(line_y1 - bottom1) - abs(top2 - line_y1)) < 2.0:
+                                ret_val = True
+                        else:
                             ret_val = True
-                    else:
-                        ret_val = True
-                    break
-                elif x_axis_relaxed and \
-                        bottom1 <= line['y1'] <= (top2 + 2.0) and \
-                        line['x1'] <= left1 < line['x2'] and \
-                        line['x1'] < right1 <= line['x2']:
-                    if check_gap:
-                        if abs(abs(line['y1'] - bottom1) - abs(top2 - line['y1'])) < 2.0:
+                        break
+                    elif x_axis_relaxed and \
+                            bottom1 <= line_y1 <= (top2 + 2.0) and \
+                            line_x1 <= left1 < line_x2 and \
+                            line_x1 < right1 <= line_x2:
+                        if check_gap:
+                            if abs(abs(line_y1 - bottom1) - abs(top2 - line_y1)) < 2.0:
+                                ret_val = True
+                        else:
                             ret_val = True
-                    else:
-                        ret_val = True
-                    break
+                        break
+                except (ValueError, TypeError):
+                    # Skip lines with invalid coordinate values
+                    continue
         return ret_val
 
     def check_block_within_svg_tags(self, block, prev_block):


### PR DESCRIPTION
…inates to float

Fixed TypeError '<=' not supported between instances of 'float' and 'str' in visual_ingestor.py by adding proper type conversion for line coordinates. The method now safely converts string coordinate values to float before comparison, with error handling to prevent crashes on invalid values.

## Description of the change

> Description here

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]()

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request
